### PR TITLE
Add kovan to presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,64 +10,85 @@
 <br>
 
 ### Notice
-* **Alpha software, eth-provider is a work in progress and not ready for production use**
-* Evolving with [EIP 1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md)
-* Testing and feedback is very much appreciated!
+
+- **Alpha software, eth-provider is a work in progress and not ready for production use**
+- Evolving with [EIP 1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md)
+- Testing and feedback is very much appreciated!
 
 ### Goals
-* Support all transport types
-* Attempt connection to an array of RPC endpoints until success
-* Reconnect when connection is lost
-* Emit helpful status updates so apps can handle changes gracefully
-* Implement `eth_pollSubscriptions` method for HTTP subscriptions (supported by [Frame](https://github.com/floating/frame))
+
+- Support all transport types
+- Attempt connection to an array of RPC endpoints until success
+- Reconnect when connection is lost
+- Emit helpful status updates so apps can handle changes gracefully
+- Implement `eth_pollSubscriptions` method for HTTP subscriptions (supported by [Frame](https://github.com/floating/frame))
 
 ### Install
+
 ```
 npm install eth-provider --save
 ```
 
 ### Use
+
 ```js
-const provider = require('eth-provider')
-const web3 = new Web3(provider())
+const provider = require("eth-provider");
+const web3 = new Web3(provider());
 ```
-* By default, eth-provider will first try to discover providers injected by the environment, usually by a browser or extension
-* If eth-provider fails to find an injected provider it will attempt to connect to local providers running on the user's device like [Frame](https://github.com/floating/frame), Geth or Parity
-* You can override these defaults by passing in your own RPC targets
+
+- By default, eth-provider will first try to discover providers injected by the environment, usually by a browser or extension
+- If eth-provider fails to find an injected provider it will attempt to connect to local providers running on the user's device like [Frame](https://github.com/floating/frame), Geth or Parity
+- You can override these defaults by passing in your own RPC targets
+
 ```js
-const provider = require('eth-provider')
-const web3 = new Web3(provider('wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b'))
+const provider = require("eth-provider");
+const web3 = new Web3(
+  provider("wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b")
+);
 ```
-* When passing in multiple RPC targets order them by priority
-* When eth-provider fails to connect to a target it will automatically attempt to connect to the next priority target
-* For example `['injected', 'wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b']` will first try to discover injected providers and if unsuccessful connect to the Infura endpoint
+
+- When passing in multiple RPC targets order them by priority
+- When eth-provider fails to connect to a target it will automatically attempt to connect to the next priority target
+- For example `['injected', 'wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b']` will first try to discover injected providers and if unsuccessful connect to the Infura endpoint
+
 ```js
-const provider = require('eth-provider')
-const web3 = new Web3(provider(['injected', 'wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b']))
+const provider = require("eth-provider");
+const web3 = new Web3(
+  provider([
+    "injected",
+    "wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b"
+  ])
+);
 ```
-* In Node and Electron you'll have access to IPC endpoints created by Geth or Parity that cannot be accessed by the Browser. You can connect to these by using the `'direct'` preset, or by passing custom IPC paths
+
+- In Node and Electron you'll have access to IPC endpoints created by Geth or Parity that cannot be accessed by the Browser. You can connect to these by using the `'direct'` preset, or by passing custom IPC paths
+
 ```js
-const provider = require('eth-provider')
-const web3 = new Web3(provider('direct'))
+const provider = require("eth-provider");
+const web3 = new Web3(provider("direct"));
 ```
 
 ### Presets
-* **`injected`** - Discover providers injected by environment, usually by the browser or a browser extension
-  * Browser
-    * `['injected']`
-* **`frame`** - Connect to [Frame](https://github.com/floating/frame) running on the user's device
-  * Browser/Node/Electron
-    * `['ws://127.0.0.1:1248', 'http://127.0.0.1:1248']`
-* **`direct`** - Connect to local Ethereum nodes running on the user's device
-  * Browser
-    * `['ws://127.0.0.1:8546', 'http://127.0.0.1:8545']`
-  * Node/Electron
-    * `[/* Default IPC paths for platform */, 'ws://127.0.0.1:8546', 'http://127.0.0.1:8545']`
-* **`infura`** - Connect to Mainnet Infura
-  * Browser/Node/Electron
-    * `['wss://mainnet.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://mainnet.infura.io/v3/786ade30f36244469480aa5c2bf0743b']`
-* **`infuraRinkeby`** - Connect to Rinkeby Infura
-  * Browser/Node/Electron
-    * `['wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://rinkeby.infura.io/v3/786ade30f36244469480aa5c2bf0743b']`
+
+- **`injected`** - Discover providers injected by environment, usually by the browser or a browser extension
+  - Browser
+    - `['injected']`
+- **`frame`** - Connect to [Frame](https://github.com/floating/frame) running on the user's device
+  - Browser/Node/Electron
+    - `['ws://127.0.0.1:1248', 'http://127.0.0.1:1248']`
+- **`direct`** - Connect to local Ethereum nodes running on the user's device
+  - Browser
+    - `['ws://127.0.0.1:8546', 'http://127.0.0.1:8545']`
+  - Node/Electron
+    - `[/* Default IPC paths for platform */, 'ws://127.0.0.1:8546', 'http://127.0.0.1:8545']`
+- **`infura`** - Connect to Mainnet Infura
+  - Browser/Node/Electron
+    - `['wss://mainnet.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://mainnet.infura.io/v3/786ade30f36244469480aa5c2bf0743b']`
+- **`infuraRinkeby`** - Connect to Rinkeby Infura
+  - Browser/Node/Electron
+    - `['wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://rinkeby.infura.io/v3/786ade30f36244469480aa5c2bf0743b']`
+- **`infuraKovan`** - Connect to Kovan Infura
+  - Browser/Node/Electron
+    - `['wss://kovan.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://kovan.infura.io/v3/786ade30f36244469480aa5c2bf0743b']`
 
 If you do not pass any targets, eth-provider will use default targets `['injected', 'frame']` in the Browser and `['frame', 'direct']` in Node and Electron.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-provider",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4304,7 +4304,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.36",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/presets/index.js
+++ b/presets/index.js
@@ -2,6 +2,16 @@ module.exports = {
   injected: ['injected'],
   frame: ['ws://127.0.0.1:1248', 'http://127.0.0.1:1248'],
   direct: ['ws://127.0.0.1:8546', 'http://127.0.0.1:8545'], // IPC paths will be prepended in Node/Electron
-  infura: ['wss://mainnet.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://mainnet.infura.io/v3/786ade30f36244469480aa5c2bf0743b'],
-  infuraRinkeby: ['wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b', 'https://rinkeby.infura.io/v3/786ade30f36244469480aa5c2bf0743b']
+  infura: [
+    'wss://mainnet.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b',
+    'https://mainnet.infura.io/v3/786ade30f36244469480aa5c2bf0743b'
+  ],
+  infuraRinkeby: [
+    'wss://rinkeby.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b',
+    'https://rinkeby.infura.io/v3/786ade30f36244469480aa5c2bf0743b'
+  ],
+  infuraKovan: [
+    'wss://kovan.infura.io/ws/v3/786ade30f36244469480aa5c2bf0743b',
+    'https://kovan.infura.io/v3/786ade30f36244469480aa5c2bf0743b'
+  ]
 }


### PR DESCRIPTION
Adds Kovan to presets so one can initialize a `infuraKovan` provider.

I have a auto-prettier plugin that prettified `README.md` and `presets/index.js`. I'm happy to undo these changes if if requested.