### PR TITLE
Set header on HTTP connection

### DIFF
--- a/connections/http.js
+++ b/connections/http.js
@@ -14,7 +14,6 @@ class HTTPConnection extends EventEmitter {
     this.status = 'loading'
     this.url = url
     this.pollId = uuid()
-    this.post = { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     setTimeout(() => this.create(), 0)
   }
   create () {
@@ -92,8 +91,8 @@ class HTTPConnection extends EventEmitter {
         }
       }
     }
-    try { this.post.body = JSON.stringify(payload) } catch (e) { return res(e) }
     xhr.open('POST', this.url, true)
+    xhr.setRequestHeader('Content-Type', 'application/json')
     xhr.timeout = 60 * 1000
     xhr.onerror = res
     xhr.ontimeout = res


### PR DESCRIPTION
header was prepared, but not actually set on http request.
Parity insists on the header, so this change fixes connectivity from frame if IPC is not available.