### PR TITLE
Move from the Node events module to eventemitter3

### DIFF
--- a/ConnectionManager/index.js
+++ b/ConnectionManager/index.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 
 const dev = process.env.NODE_ENV === 'development'
 

--- a/connections/http.js
+++ b/connections/http.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 const { v4: uuid } = require('uuid')
 
 const dev = process.env.NODE_ENV === 'development'

--- a/connections/injected.js
+++ b/connections/injected.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 
 class InjectedConnection extends EventEmitter {
   constructor (_injected, options) {

--- a/connections/ipc.js
+++ b/connections/ipc.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 const oboe = require('oboe')
 const parse = require('../parse')
 const dev = process.env.NODE_ENV === 'development'

--- a/connections/unavailable.js
+++ b/connections/unavailable.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 
 class UnavailableConnection extends EventEmitter {
   constructor (message) {

--- a/connections/ws.js
+++ b/connections/ws.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 const parse = require('../parse')
 const dev = process.env.NODE_ENV === 'development'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1998,10 +1998,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -2721,9 +2720,9 @@
       "dev": true
     },
     "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -4961,6 +4960,14 @@
       "dev": true,
       "requires": {
         "eventemitter3": "3.1.2"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        }
       }
     },
     "web3-core-requestmanager": {
@@ -4985,6 +4992,14 @@
         "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.8"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        }
       }
     },
     "web3-eth": {
@@ -5184,14 +5199,6 @@
         "eventemitter3": "^4.0.0",
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.8"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-          "dev": true
-        }
       }
     },
     "web3-shh": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "repository": "github:floating/eth-provider",
   "dependencies": {
     "ethereum-provider": "0.2.0",
+    "eventemitter3": "^4.0.7",
     "oboe": "2.1.5",
     "uuid": "8.3.1",
     "ws": "7.4.0",

--- a/provider/index.js
+++ b/provider/index.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 const EthereumProvider = require('ethereum-provider')
 const ConnectionManager = require('../ConnectionManager')
 


### PR DESCRIPTION
This removes the need for bundlers to polyfill the Node `events` module in order to use eth-provider.

The [`events` module on npm](https://www.npmjs.com/package/events) could also work, but [`eventemitter3`](https://github.com/primus/eventemitter3) has a few advantages over it.